### PR TITLE
Added VehicleKilled event handling into update arena event

### DIFF
--- a/replay_parser/src/packet_parser/events/entity_method/update_arena.rs
+++ b/replay_parser/src/packet_parser/events/entity_method/update_arena.rs
@@ -188,10 +188,11 @@ fn parse_avatar_ready(arena_data: &[u8]) -> Result<UpdateData, PacketError> {
 }
 #[derive(Debug, Clone, Serialize, Version)]
 pub struct VehicleKilled {
-    pub victim_id:     i32,
-    pub killer_id:     i32,
-    pub equipment_id:  i32,
-    pub attack_reason: AttackReason,
+    pub victim_id:             i32,
+    pub killer_id:             i32,
+    pub equipment_id:          i32,
+    pub attack_reason:         AttackReason,
+    pub num_vehicles_affected: i32,
 }
 
 fn parse_vehicle_killed(arena_data: &[u8]) -> Result<UpdateData, PacketError> {
@@ -209,8 +210,9 @@ fn parse_vehicle_killed(arena_data: &[u8]) -> Result<UpdateData, PacketError> {
             PacketError::WrongEnumVariant(format!("arena attack reason of {attack_reason} is invalid"))
         })?,
         victim_id: parse_value(0, &thing)?,
-        equipment_id: parse_value(2, &thing)?,
         killer_id: parse_value(1, &thing)?,
+        equipment_id: parse_value(2, &thing)?,
+        num_vehicles_affected: parse_value(4, &thing)?,
     };
 
     Ok(UpdateData::VehicleKilled(vehicle_killed))

--- a/replay_parser/src/packet_parser/events/entity_method/update_arena.rs
+++ b/replay_parser/src/packet_parser/events/entity_method/update_arena.rs
@@ -192,7 +192,9 @@ pub struct VehicleKilled {
     pub killer_id:             i32,
     pub equipment_id:          i32,
     pub attack_reason:         AttackReason,
-    pub num_vehicles_affected: i32,
+
+    #[version([1, 17, 0, 0])]
+    pub num_vehicles_affected: Option<i32>,
 }
 
 fn parse_vehicle_killed(arena_data: &[u8]) -> Result<UpdateData, PacketError> {
@@ -203,6 +205,12 @@ fn parse_vehicle_killed(arena_data: &[u8]) -> Result<UpdateData, PacketError> {
 
     let PickleVal::Tuple(thing) = pickle_value else { todo!() };
 
+    let num_vehicles_affected = if thing.len() > 4 {
+        parse_value(4, &thing)?
+    } else {
+        None
+    };
+
     let attack_reason: i32 = parse_value(3, &thing)?;
 
     let vehicle_killed = VehicleKilled {
@@ -212,7 +220,7 @@ fn parse_vehicle_killed(arena_data: &[u8]) -> Result<UpdateData, PacketError> {
         victim_id: parse_value(0, &thing)?,
         killer_id: parse_value(1, &thing)?,
         equipment_id: parse_value(2, &thing)?,
-        num_vehicles_affected: parse_value(4, &thing)?,
+        num_vehicles_affected,
     };
 
     Ok(UpdateData::VehicleKilled(vehicle_killed))

--- a/replay_parser/src/packet_parser/events/entity_method/update_arena.rs
+++ b/replay_parser/src/packet_parser/events/entity_method/update_arena.rs
@@ -15,6 +15,7 @@ pub struct UpdateArena {
 pub enum UpdateData {
     VehicleList(Vec<VehicleData>),
     AvatarReady(AvatarReady),
+    VehicleKilled(VehicleKilled),
     Unimplemented,
 }
 
@@ -33,6 +34,7 @@ impl UpdateArena {
         let update_data = match update_type {
             VehicleList => parse_vehicle_list(arena_data)?,
             AvatarReady => parse_avatar_ready(arena_data)?,
+            VehicleKilled => parse_vehicle_killed(arena_data)?,
             _ => UpdateData::Unimplemented,
         };
 
@@ -191,4 +193,22 @@ pub struct VehicleKilled {
     pub equipment_id: i32,
     pub reason:       i32,
     //TODO: More fields in later versions
+}
+
+fn parse_vehicle_killed(arena_data: &[u8]) -> Result<UpdateData, PacketError> {
+    let pickle_value = serde_pickle::value_from_slice(
+        arena_data,
+        serde_pickle::DeOptions::new().replace_unresolved_globals(),
+    )?;
+
+    let PickleVal::Tuple(thing) = pickle_value else { todo!() };
+
+    let vehicle_killed = VehicleKilled {
+        reason: parse_value(3, &thing)?,
+        victim_id: parse_value(0, &thing)?,
+        equipment_id: 0,
+        killer_id: parse_value(1, &thing)?,
+    };
+
+    Ok(UpdateData::VehicleKilled(vehicle_killed))
 }

--- a/replay_parser/src/packet_parser/events/entity_method/update_arena.rs
+++ b/replay_parser/src/packet_parser/events/entity_method/update_arena.rs
@@ -209,7 +209,7 @@ fn parse_vehicle_killed(arena_data: &[u8]) -> Result<UpdateData, PacketError> {
             PacketError::WrongEnumVariant(format!("arena attack reason of {attack_reason} is invalid"))
         })?,
         victim_id: parse_value(0, &thing)?,
-        equipment_id: 0,
+        equipment_id: parse_value(2, &thing)?,
         killer_id: parse_value(1, &thing)?,
     };
 

--- a/wot_types/src/arena_attack_reasons.rs
+++ b/wot_types/src/arena_attack_reasons.rs
@@ -1,0 +1,38 @@
+use num_enum::TryFromPrimitive;
+use serde::Serialize;
+
+
+// Took from https://github.com/IzeBerg/wot-src/blob/EU/sources/res/scripts/common/constants.py
+// ATTACK_REASONS = (...
+#[repr(i32)]
+#[derive(PartialEq, Hash, Eq, Copy, Clone, Debug, TryFromPrimitive, strum::Display, Serialize)]
+pub enum AttackReason {
+    Shot                    = 0,
+    Fire                    = 1,
+    Ram                     = 2,
+    WorldCollision          = 3,
+    DeathZone               = 4,
+    Drowing                 = 5,
+    GasAttack               = 6,
+    Overturn                = 7,
+    Manual                  = 8,
+    ArtilleryProtection     = 9,
+    ArtillerySector         = 10,
+    Bombers                 = 11,
+    Recovery                = 12,
+    Artillery               = 13,
+    Bomber                  = 14,
+    Minefield               = 15,
+    None                    = 16,
+    SpawnedBotExplosion     = 17,
+    Berserker               = 18,
+    Smoke                   = 19,
+    CorrogingShot           = 20,
+    AdaptationHealthRestore = 21,
+    ThunderStrike           = 22,
+    FireCircle              = 23,
+    ClingBrander            = 24,
+    ClingBranderRam         = 25,
+    BranderRam              = 26,
+    FortArtillery           = 27,
+}

--- a/wot_types/src/arena_attack_reasons.rs
+++ b/wot_types/src/arena_attack_reasons.rs
@@ -12,7 +12,7 @@ pub enum AttackReason {
     Ram                     = 2,
     WorldCollision          = 3,
     DeathZone               = 4,
-    Drowing                 = 5,
+    Drowning                = 5,
     GasAttack               = 6,
     Overturn                = 7,
     Manual                  = 8,

--- a/wot_types/src/lib.rs
+++ b/wot_types/src/lib.rs
@@ -6,3 +6,6 @@ pub use wot_value::WotValue;
 
 mod arena_update;
 pub use arena_update::ArenaUpdate;
+
+mod arena_attack_reasons;
+pub use arena_attack_reasons::AttackReason;


### PR DESCRIPTION
Edit: I found the remaining field. It seems to be the number of affected vehicles describe here:
```python
def __onVehicleKilled(self, targetID, attackerID, equipmentID, reason, numVehiclesAffected):
```

I don't known if you want an "Unknown" field in the death reason that I've added or you prefer an Exception.


Sorry for the notifications, i updated my pull request so many times...