### PR TITLE
Arena events: Added VehicleAdded event and VehicleUpdated

### DIFF
--- a/replay_parser/src/packet_parser/events/entity_method/avatar_methods/update_arena/base.rs
+++ b/replay_parser/src/packet_parser/events/entity_method/avatar_methods/update_arena/base.rs
@@ -1,6 +1,6 @@
 use serde_pickle::Value as PickleVal;
 
-use super::{parse_value, ArenaUpdateData};
+use super::{parse_truthy_value, parse_value, ArenaUpdateData};
 use crate::packet_parser::prelude::*;
 
 #[derive(Debug, Clone, Serialize, Version)]
@@ -33,7 +33,7 @@ pub fn parse_base_points(arena_data: &[u8]) -> Result<ArenaUpdateData, PacketErr
             points:            parse_value(2, &thing)?,
             time_left:         parse_value(3, &thing)?,
             invaders_cnt:      parse_value(4, &thing)?,
-            capturing_stopped: parse_value::<i64>(5, &thing)? != 0,
+            capturing_stopped: parse_truthy_value(5, &thing)? != 0,
         }))
     } else {
         Ok(ArenaUpdateData::BasePoints(BasePoints {
@@ -42,7 +42,7 @@ pub fn parse_base_points(arena_data: &[u8]) -> Result<ArenaUpdateData, PacketErr
             points:            parse_value(2, &thing)?,
             time_left:         None,
             invaders_cnt:      None,
-            capturing_stopped: parse_value::<i64>(3, &thing)? != 0,
+            capturing_stopped: parse_truthy_value(3, &thing)? != 0,
         }))
     }
 }

--- a/replay_parser/src/packet_parser/events/entity_method/avatar_methods/update_arena/mod.rs
+++ b/replay_parser/src/packet_parser/events/entity_method/avatar_methods/update_arena/mod.rs
@@ -2,10 +2,12 @@ mod avatar_ready;
 mod base;
 mod fog_of_war;
 mod period;
+mod vehicle_added;
 mod vehicle_descr;
 mod vehicle_killed;
 mod vehicle_list;
 mod vehicle_statistics;
+mod vehicle_updated;
 
 use avatar_ready::{parse_avatar_ready, AvatarReady};
 use base::{parse_base_captured, parse_base_points, BaseCaptured, BasePoints};
@@ -13,10 +15,12 @@ use fog_of_war::{parse_fog_of_war, FogOfWar};
 use nom::number::complete::le_u8;
 use period::{parse_period, Period};
 use serde_pickle::Value as PickleVal;
+use vehicle_added::parse_vehicle_added;
 use vehicle_descr::{parse_vehicle_descr, VehicleDescr};
 use vehicle_killed::{parse_vehicle_killed, VehicleKilled};
 use vehicle_list::{parse_vehicle_list, VehicleData};
 use vehicle_statistics::{parse_statistics, parse_vehicle_statistics, VehicleStatistics};
+use vehicle_updated::parse_vehicle_updated;
 use wot_types::ArenaUpdate;
 
 use crate::packet_parser::prelude::*;
@@ -40,6 +44,8 @@ pub enum ArenaUpdateData {
     Period(Period),
     VehicleDescr(VehicleDescr),
     FogOfWar(FogOfWar),
+    VehicleAdded(VehicleData),
+    VehicleUpdated(VehicleData),
     Unimplemented,
 }
 
@@ -64,6 +70,8 @@ impl UpdateArena {
             Period => parse_period(arena_data)?,
             VehicleDescr => parse_vehicle_descr(arena_data)?,
             FogOfWar => parse_fog_of_war(arena_data)?,
+            VehicleAdded => parse_vehicle_added(arena_data)?,
+            VehicleUpdated => parse_vehicle_updated(arena_data)?,
             _ => ArenaUpdateData::Unimplemented,
         };
 

--- a/replay_parser/src/packet_parser/events/entity_method/avatar_methods/update_arena/vehicle_added.rs
+++ b/replay_parser/src/packet_parser/events/entity_method/avatar_methods/update_arena/vehicle_added.rs
@@ -1,0 +1,21 @@
+use serde_pickle::Value as PickleVal;
+
+use super::ArenaUpdateData;
+use crate::{
+    events::entity_method::avatar_methods::update_arena::vehicle_list::parse_vehicle_data,
+    packet_parser::prelude::*,
+};
+
+pub fn parse_vehicle_added(arena_data: &[u8]) -> Result<ArenaUpdateData, PacketError> {
+    let decompressed =
+        utils::decompress_vec(arena_data, |err| PacketError::ConversionError(err.to_string()))?;
+    let pickle_value = serde_pickle::value_from_slice(
+        &decompressed,
+        serde_pickle::DeOptions::new().replace_unresolved_globals(),
+    )
+    .unwrap();
+
+    let PickleVal::Tuple(vehicle_data) = pickle_value  else { todo!() };
+
+    Ok(ArenaUpdateData::VehicleAdded(parse_vehicle_data(vehicle_data)?))
+}

--- a/replay_parser/src/packet_parser/events/entity_method/avatar_methods/update_arena/vehicle_updated.rs
+++ b/replay_parser/src/packet_parser/events/entity_method/avatar_methods/update_arena/vehicle_updated.rs
@@ -1,0 +1,21 @@
+use serde_pickle::Value as PickleVal;
+
+use super::ArenaUpdateData;
+use crate::{
+    events::entity_method::avatar_methods::update_arena::vehicle_list::parse_vehicle_data,
+    packet_parser::prelude::*,
+};
+
+pub fn parse_vehicle_updated(arena_data: &[u8]) -> Result<ArenaUpdateData, PacketError> {
+    let decompressed =
+        utils::decompress_vec(arena_data, |err| PacketError::ConversionError(err.to_string()))?;
+    let pickle_value = serde_pickle::value_from_slice(
+        &decompressed,
+        serde_pickle::DeOptions::new().replace_unresolved_globals(),
+    )
+    .unwrap();
+
+    let PickleVal::Tuple(vehicle_data) = pickle_value  else { todo!() };
+
+    Ok(ArenaUpdateData::VehicleUpdated(parse_vehicle_data(vehicle_data)?))
+}


### PR DESCRIPTION
I also made the field `vehicle_compact_descr` optional. During global map game you can spot enemy vehicles without knowing his vehicle type.
![vehicle-added-unknow](https://user-images.githubusercontent.com/37590995/219963622-328056e4-8efe-4b60-8eb3-e87c13f08d6f.png)
